### PR TITLE
Update QUBO: construct QUBO from graph

### DIFF
--- a/src/ProblemReductions.jl
+++ b/src/ProblemReductions.jl
@@ -24,7 +24,7 @@ export IndependentSet
 export VertexCovering, is_vertex_covering, vertex_covering_energy
 export SetPacking, is_set_packing
 export DominatingSet
-export QUBO, QUBO_from_SimpleGraph
+export QUBO
 
 # rules
 export target_problem, AbstractProblem, AbstractReductionResult, reduceto, extract_solution, reduction_complexity

--- a/src/ProblemReductions.jl
+++ b/src/ProblemReductions.jl
@@ -24,7 +24,7 @@ export IndependentSet
 export VertexCovering, is_vertex_covering, vertex_covering_energy
 export SetPacking, is_set_packing
 export DominatingSet
-export QUBO
+export QUBO, QUBO_from_SimpleGraph
 
 # rules
 export target_problem, AbstractProblem, AbstractReductionResult, reduceto, extract_solution, reduction_complexity

--- a/src/models/QUBO.jl
+++ b/src/models/QUBO.jl
@@ -15,6 +15,19 @@ struct QUBO{QT<:AbstractMatrix} <: AbstractProblem
     end
 end
 Base.:(==)(a::QUBO, b::QUBO) = a.matrix == b.matrix
+function QUBO_from_SimpleGraph(graph::SimpleGraph, weights::Vector)
+    @assert length(weights) == ne(graph) "length of weights must be equal to the number of edges $(ne(graph)), got: $(length(weights))"
+    Q = zeros(Float64, nv(graph), nv(graph))
+    edge_idx = 0
+    for e in edges(graph)
+        edge_idx += 1
+        i = src(e)
+        j = dst(e)
+        Q[i, j] = weights[edge_idx]
+        Q[j, i] = weights[edge_idx]
+    end
+    return QUBO(Q)
+end
 
 # variables interface
 variables(c::QUBO) = collect(1:size(c.matrix, 1))

--- a/src/models/SpinGlass.jl
+++ b/src/models/SpinGlass.jl
@@ -32,7 +32,7 @@ end
 
 # variables interface
 variables(gp::SpinGlass) = collect(1:nv(gp.graph))
-flavors(::Type{<:SpinGlass}) = [0, 1]
+flavors(::Type{<:SpinGlass}) = [1, -1]
 
 # weights interface
 parameters(gp::SpinGlass) = gp.weights
@@ -63,24 +63,21 @@ where ``C`` is the set of cliques, and ``w_c`` is the weight of the clique ``c``
 """
 function spinglass_energy(cliques::AbstractVector{Vector{Int}}, config; weights)::Real
     size = zero(eltype(weights))
-    @assert all(x->x == 0 || x == 1, config)
-    s = 1 .- 2 .* Int.(config)  # 0 -> spin 1, 1 -> spin -1
+    @assert all(x->x == -1 || x == 1, config)
     for (i, spins) in enumerate(cliques)
-        size += prod(s[spins]) * weights[i]
+        size += prod(config[spins]) * weights[i]
     end
     return size
 end
 function spinglass_energy(g::SimpleGraph, config; J, h)
     eng = zero(promote_type(eltype(J), eltype(h)))
-    # NOTE: cast to Int to avoid using unsigned Int
-    s = 1 .- 2 .* Int.(config)  # 0 -> spin 1, 1 -> spin -1
     # coupling terms
     for (i, e) in enumerate(edges(g))
-        eng += (s[e.src] * s[e.dst]) * J[i]
+        eng += (config[e.src] * config[e.dst]) * J[i]
     end
     # onsite terms
     for (i, v) in enumerate(vertices(g))
-        eng += s[v] * h[i]
+        eng += config[v] * h[i]
     end
     return eng
 end

--- a/src/models/models.jl
+++ b/src/models/models.jl
@@ -49,6 +49,24 @@ Returns a vector of integers as the flavors (domain) of a degree of freedom.
 """
 flavors(::GT) where GT<:AbstractProblem = flavors(GT)
 
+
+"""
+    flavor_to_logical(::Type{T}, flavor) -> T
+
+Convert the flavor to a logical value.
+"""
+function flavor_to_logical(::Type{T}, flavor) where T
+    flvs = flavors(T)
+    @assert length(flvs) == 2 "The number of flavors must be 2, got: $(length(flvs))"
+    if flavor == flvs[1]
+        return false
+    elseif flavor == flvs[2]
+        return true
+    else
+        error("The flavor must be one of the flavors $(flvs), got: $(flavor)")
+    end
+end
+
 """
     num_flavors(::Type{<:AbstractProblem}) -> Int
 

--- a/src/rules/spinglass_maxcut.jl
+++ b/src/rules/spinglass_maxcut.jl
@@ -27,7 +27,7 @@ end
 function extract_solution(res::ReductionMaxCutToSpinGlass, sol)
     out = zeros(eltype(sol), num_variables(res.spinglass))
     for (k, v) in enumerate(variables(res.spinglass))
-        out[v] = sol[k]
+        out[v] = sol[k] == -1
     end
     return out
 end
@@ -61,7 +61,7 @@ end
 function extract_solution(res::ReductionSpinGlassToMaxCut, sol)
     out = zeros(eltype(sol), num_variables(res.maxcut))
     for (k, v) in enumerate(variables(res.maxcut))
-        out[v] = sol[k]
+        out[v] = 1 - 2*sol[k]
     end
     return out
 end

--- a/src/rules/spinglass_sat.jl
+++ b/src/rules/spinglass_sat.jl
@@ -41,7 +41,7 @@ end
 function extract_solution(res::ReductionCircuitToSpinGlass, sol)
     out = zeros(eltype(sol), res.num_source_vars)
     for (k, v) in enumerate(res.variables)
-        out[v] = sol[k]
+        out[v] = sol[k] == -1
     end
     return out
 end
@@ -261,6 +261,7 @@ Compute the truth table of a logic gadget.
 """
 function truth_table(ga::LogicGadget; variables=1:num_variables(ga.problem), solver=BruteForce())
     res = findbest(ga.problem, solver)
-    dict = infer_logic(res, ga.inputs, ga.outputs)
+    logic_res = map(resi->flavor_to_logical.(typeof(ga.problem), resi), res)
+    dict = infer_logic(logic_res, ga.inputs, ga.outputs)
     return dict2table(variables[ga.inputs], variables[ga.outputs], dict)
 end

--- a/test/models/QUBO.jl
+++ b/test/models/QUBO.jl
@@ -1,29 +1,31 @@
-using ProblemReductions, Test, LinearAlgebra
+using ProblemReductions, Test, LinearAlgebra, Graphs
 
 @testset "qubo" begin
     # construct several QUBO problems
-    matrix01 = [[1., 0, 0], [0, 1., 0], [0, 0, 1.]]
-    Q01 = hcat(matrix01...)
-    QUBO01 = QUBO(Q01)
-    QUBO02 = QUBO(I(3))
-    @test QUBO01 == QUBO02
+    Q01 = [1. 0 0; 0 1 0; 0 0 1]
+    q01 = QUBO(Q01, zeros(3))
+    @test q01 isa QUBO
 
     # QUBO from Graph
     graph = SimpleGraph(3)
     add_edge!(graph, 1, 1)
     add_edge!(graph, 2, 2)
     add_edge!(graph, 3, 3)
-    QUBO03 = QUBO_from_SimpleGraph(graph, [1., 1., 1.])
-    @test QUBO01 == QUBO03
+    q03 = QUBO(graph, [2., 2., 2.], zeros(3))
+    @test q01 == q03
     
     # variables
-    @test variables(QUBO01) == [1, 2, 3]
-    @test num_variables(QUBO01) == 3
-    @test flavors(QUBO01) == [0, 1]
-    @test num_flavors(QUBO01) == 2
+    @test variables(q01) == [1, 2, 3]
+    @test num_variables(q01) == 3
+    @test flavors(q01) == [0, 1]
+    @test num_flavors(q01) == 2
 
     # evaluate
-    @test evaluate(QUBO01, [0, 0, 0]) == 0
-    @test evaluate(QUBO01, [1, 1, 0]) == 2
-    @test findbest(QUBO01, BruteForce()) == [ [0, 0, 0] ]
+    @test evaluate(q01, [0, 0, 0]) == 0
+    @test evaluate(q01, [1, 1, 0]) == 2
+    @test findbest(q01, BruteForce()) == [[0, 0, 0]]
+
+    # the OR gadget
+    q04 = QUBO([0 1 -2; 1 0 -2; -2 -2 0], [2, 2, 2])
+    @test sort(findbest(q04, BruteForce())) == [[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]]
 end

--- a/test/models/QUBO.jl
+++ b/test/models/QUBO.jl
@@ -2,13 +2,20 @@ using ProblemReductions, Test, LinearAlgebra
 
 @testset "qubo" begin
     # construct several QUBO problems
-    matrix01 = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    matrix01 = [[1., 0, 0], [0, 1., 0], [0, 0, 1.]]
     Q01 = hcat(matrix01...)
     QUBO01 = QUBO(Q01)
     QUBO02 = QUBO(I(3))
     @test QUBO01 == QUBO02
-    
 
+    # QUBO from Graph
+    graph = SimpleGraph(3)
+    add_edge!(graph, 1, 1)
+    add_edge!(graph, 2, 2)
+    add_edge!(graph, 3, 3)
+    QUBO03 = QUBO_from_SimpleGraph(graph, [1., 1., 1.])
+    @test QUBO01 == QUBO03
+    
     # variables
     @test variables(QUBO01) == [1, 2, 3]
     @test num_variables(QUBO01) == 3

--- a/test/models/SpinGlass.jl
+++ b/test/models/SpinGlass.jl
@@ -11,14 +11,14 @@ using ProblemReductions, Test, Graphs
     # variables
     @test variables(sg) == [1, 2, 3]
     @test num_variables(sg) == 3
-    @test flavors(sg) == [0, 1]
+    @test flavors(sg) == [1, -1]
     @test num_flavors(sg) == 2
 
     # parameters
     @test parameters(sg) == [1, -2, -2, 1, 1, -2]
     @test set_parameters(sg, [1, 2, 2, -1, -1, -2]) == SpinGlass(g, [1, 2, 2], [-1, -1, -2])
 
-    @test evaluate(sg, [0, 0, 0]) == -3
+    @test evaluate(sg, [1, 1, 1]) == -3
     configs = findbest(sg, BruteForce())
     for cfg in configs
         @test cfg[3] == cfg[1] & cfg[2]

--- a/test/rules/rules.jl
+++ b/test/rules/rules.jl
@@ -29,6 +29,7 @@ end
             spinglass => MaxCut,
             vertexcovering => SetCovering
         ]
+        @info "Testing reduction from $(typeof(source)) to $(target_type)"
         # directly solve
         best_source = findbest(source, BruteForce())
 

--- a/test/rules/spinglass_maxcut.jl
+++ b/test/rules/spinglass_maxcut.jl
@@ -17,5 +17,5 @@ using ProblemReductions: maxcut2spinglass
     @test reduceto(SpinGlass, mc) == res
     @test maxcut2spinglass(mc) == SpinGlass(g, [1, 3, 1, 4])
     @test findbest(mc, BruteForce()) == [[0, 0, 1, 0], [0, 1, 1, 0], [1, 0, 0, 1], [1, 1, 0, 1]] # in lexicographic order
-    @test findbest(maxcut2spinglass(mc), BruteForce()) == [[0, 0, 1, 0], [0, 1, 1, 0], [1, 0, 0, 1], [1, 1, 0, 1]] # in lexicographic order
+    @test sort(findbest(maxcut2spinglass(mc), BruteForce())) == sort([[1, 1, -1, 1], [1, -1, -1, 1], [-1, 1, 1, -1], [-1, -1, 1, -1]]) # in lexicographic order
 end

--- a/test/rules/spinglass_sat.jl
+++ b/test/rules/spinglass_sat.jl
@@ -4,17 +4,17 @@ using ProblemReductions.BitBasis
 
 @testset "gates" begin
     res = findbest(spinglass_gadget(:∧).problem, BruteForce())
-    @test collect.(sort(res)) == [[0, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 1]]
+    @test collect.(sort(res)) == sort([[1, 1, 1], [1, -1, 1], [-1, 1, 1], [-1, -1, -1]])
     tt = truth_table(spinglass_gadget(:∧))
     @test length(tt) == 4
     @test tt[bit"00"] == tt[bit"01"] == tt[bit"10"] == bit"0"
     @test tt[bit"11"] == bit"1"
 
     res = findbest(spinglass_gadget(:∨).problem, BruteForce())
-    @test collect.(sort(res)) == [[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]]
+    @test collect.(sort(res)) == sort([[1, 1, 1], [1, -1, -1], [-1, 1, -1], [-1, -1, -1]])
 
     res = findbest(spinglass_gadget(:¬).problem, BruteForce())
-    @test collect.(sort(res)) == [[0, 1], [1, 0]]
+    @test collect.(sort(res)) == sort([[1, -1], [-1, 1]])
 end
 
 @testset "arraymul" begin
@@ -36,6 +36,7 @@ end
     @test length(tt) == 16
     ProblemReductions.set_input!(arr, [0, 1, 0, 1])  # 2 x 2 == 4
     res = findbest(arr.problem, BruteForce())
+    res = map(resi->map(==(-1), resi), res)
     @test ProblemReductions.infer_logic(res, arr.inputs, arr.outputs) == Dict([0, 1, 0, 1] => [0, 0, 1, 0])
 end
 


### PR DESCRIPTION
This is an update of QUBO problem #54 :
* I add a function which can construct QUBO from a simple graph. The inputs are: a simple graph and a weights vector.

Maybe we can further construct QUBO directly from simple weighted graph as suggested by @hmyuuu (to make the interface more robust?). But I am not sure whether this would be redundant.