### PR TITLE
Update reduction rule: General SAT to Independent Set

### DIFF
--- a/src/rules/sat_independentset.jl
+++ b/src/rules/sat_independentset.jl
@@ -10,16 +10,8 @@ end
 target_problem(res::ReductionSATToIndependentSet) = res.is_target
 
 @with_complexity 1 function reduceto(::Type{<:IndependentSet}, sat_source::Satisfiability)
-    is_target, k, literal_to_nodes = reduce_3sat_to_independent_set(sat_source)
+    is_target, k, literal_to_nodes = reduce_sat_to_independent_set(sat_source)
     return ReductionSATToIndependentSet(sat_source, is_target, k, literal_to_nodes )
-end
-
-function extract_solution(res::ReductionSATToIndependentSet, sol)
-    if count(x == 1 for x in sol[1]) >= res.k
-        return transform_is_to_sat_solution(res.sat_source, sol, res.literal_to_nodes )
-    else
-        return Vector{Int}()
-    end
 end
 
 function extract_solution(res::ReductionSATToIndependentSet, sol)

--- a/test/models/Satisfiability.jl
+++ b/test/models/Satisfiability.jl
@@ -10,10 +10,10 @@ using ProblemReductions: KSatisfiability,clauses
 
     cnf_test = CNF([clause1, clause2])
     sat_test = Satisfiability(cnf_test)
-    ksat_test = KSatisfiability{3}(cnf_test)
+    
     @test sat_test isa Satisfiability
     @test clauses(sat_test) == cnf_test.clauses
-    @test clauses(ksat_test) == cnf_test.clauses
+    
     @test is_kSAT(sat_test.cnf, 3)
     vars = ["x", "y", "z", "w"]
     @test variables(sat_test) == vars
@@ -33,14 +33,15 @@ using ProblemReductions: KSatisfiability,clauses
     res = findbest(sat_test, BruteForce())
     @test length(res) == 14
 
-    # KSatisfiability version (a copy of above tests)
-    sat_test_ksat = KSatisfiability{3}(cnf_test)
-    @test sat_test_ksat isa KSatisfiability
-    @test variables(sat_test_ksat) == vars
-    @test num_variables(sat_test_ksat) == 4
+    # Tests for KSatisfiability
+    ksat_test = KSatisfiability{3}(cnf_test)
+    @test clauses(ksat_test) == cnf_test.clauses
+    @test ksat_test isa KSatisfiability
+    @test variables(ksat_test) == vars
+    @test num_variables(ksat_test) == 4
 
     cfg = [0, 1, 0, 1]
     assignment = Dict(zip(vars, cfg))
-    @test satisfiable(sat_test_ksat.cnf, assignment) == true
-    @test evaluate(sat_test_ksat, cfg) == 0
+    @test satisfiable(ksat_test.cnf, assignment) == true
+    @test evaluate(ksat_test, cfg) == 0
 end

--- a/test/rules/rules.jl
+++ b/test/rules/rules.jl
@@ -53,7 +53,8 @@ end
             qubo => SpinGlass,
             spinglass2 => QUBO,
             sat => KSatisfiability,
-            ksat => Satisfiability
+            ksat => Satisfiability,
+            sat => IndependentSet
         ]
         @info "Testing reduction from $(typeof(source)) to $(target_type)"
         # directly solve

--- a/test/rules/rules.jl
+++ b/test/rules/rules.jl
@@ -70,4 +70,5 @@ end
         # check if the solutions are the same
         @test unique!(sort(best_source)) == unique!(sort(best_source_extracted))
     end
+
 end

--- a/test/rules/sat_independentset.jl
+++ b/test/rules/sat_independentset.jl
@@ -52,7 +52,6 @@ using Test, ProblemReductions, Graphs
     @test reduction_complexity(IndependentSet, sat04) == 1
     IS04 = reduction_results_04.is_target
     sol_IS_04 = findbest( IS04, BruteForce() )
-    # @test extract_solution(reduction_results_04, sol_IS_04) == Vector{Int64}()
     @test Set( findbest( sat04, BruteForce() ) ) == Set( extract_solution(reduction_results_04, sol_IS_04) )
 
     # Example 005: unsatisfiable 1-SAT (equivalent with example 004)

--- a/test/rules/sat_independentset.jl
+++ b/test/rules/sat_independentset.jl
@@ -2,7 +2,7 @@ using Test, ProblemReductions, Graphs
 
 @testset "sat_independentset" begin
 
-    # Example 001
+    # Example 001: satisfiable 3-SAT
     x1 = BoolVar(:x1, false)
     nx1 = BoolVar(:x1, true)
     x2 = BoolVar(:x2, false)
@@ -15,8 +15,8 @@ using Test, ProblemReductions, Graphs
     clause3 = CNFClause( [x1, nx2, nx3] )
     clause4 = CNFClause( [nx1, x2, x3] )
 
-    clauses = [clause1, clause2, clause3, clause4]
-    sat01 = Satisfiability(CNF(clauses))
+    clause_lst = [clause1, clause2, clause3, clause4]
+    sat01 = Satisfiability(CNF(clause_lst))
 
     reduction_results = reduceto(IndependentSet, sat01 )
     IS01 = reduction_results.is_target
@@ -25,7 +25,7 @@ using Test, ProblemReductions, Graphs
 
     @test target_problem( reduction_results ) == IS01
 
-    # Example 002
+    # Example 002: satisfiable 3-SAT
     clause5 = CNFClause( [nx1, x2, x3] )
     clause6 = CNFClause( [x1, nx2, x3] )
     clause7 = CNFClause( [x1, x2, nx3] )
@@ -35,7 +35,7 @@ using Test, ProblemReductions, Graphs
     sol_IS_02 = findbest( IS02, BruteForce() )
     @test Set( findbest( sat02, BruteForce() ) ) == Set( extract_solution(reduction_results_02, sol_IS_02) )
 
-    # Example 003
+    # Example 003: satisfiable 3-SAT
     clause8 = CNFClause( [x1, x2, x3] )
     clause9 = CNFClause( [nx1, nx2, nx3] )
     sat03 = Satisfiability( CNF([clause8, clause9]) )
@@ -44,7 +44,7 @@ using Test, ProblemReductions, Graphs
     sol_IS_03 = findbest( IS03, BruteForce() )
     @test Set( findbest( sat03, BruteForce() ) ) == Set( extract_solution(reduction_results_03, sol_IS_03) )
 
-    # Example 004
+    # Example 004: unsatisfiable 3-SAT (trivial example)
     clause10 = CNFClause( [x1, x1, x1] )
     clause11 = CNFClause( [nx1, nx1, nx1])
     sat04 = Satisfiability( CNF([clause10, clause11]) )
@@ -52,6 +52,30 @@ using Test, ProblemReductions, Graphs
     @test reduction_complexity(IndependentSet, sat04) == 1
     IS04 = reduction_results_04.is_target
     sol_IS_04 = findbest( IS04, BruteForce() )
-    @test extract_solution(reduction_results_04, sol_IS_04) == Vector{Int64}()
+    # @test extract_solution(reduction_results_04, sol_IS_04) == Vector{Int64}()
+    @test Set( findbest( sat04, BruteForce() ) ) == Set( extract_solution(reduction_results_04, sol_IS_04) )
 
+    # Example 005: unsatisfiable 1-SAT (equivalent with example 004)
+    sat05 = Satisfiability( CNF( [ CNFClause([x1]), CNFClause([nx1]) ] ) )
+    reduction_results_05 = reduceto(IndependentSet, sat05)
+    @test reduction_complexity(IndependentSet, sat05) == 1
+    IS05 = reduction_results_05.is_target
+    sol_IS_05 = findbest( IS05, BruteForce() )
+    @test Set( findbest( sat05, BruteForce() ) ) == Set( extract_solution(reduction_results_05, sol_IS_05) )
+
+    # Example 006: unsatisfiable 2-SAT
+    sat06 = Satisfiability( CNF( [ CNFClause([x1, x2]), CNFClause([x1, nx2]), CNFClause([nx1, x2]), CNFClause([nx1, nx2]) ] ) )
+    reduction_results_06 = reduceto(IndependentSet, sat06)
+    @test reduction_complexity(IndependentSet, sat06) == 1
+    IS06 = reduction_results_06.is_target
+    sol_IS_06 = findbest( IS06, BruteForce() )
+    @test Set( findbest( sat06, BruteForce() ) ) == Set( extract_solution(reduction_results_06, sol_IS_06) )
+
+    # Example 007: satisfiable 2-SAT
+    sat07 = Satisfiability( CNF( [ CNFClause([x1, x2]), CNFClause([x1, nx2]), CNFClause([nx1, x2]) ] ) )
+    reduction_results_07 = reduceto(IndependentSet, sat07)
+    @test reduction_complexity(IndependentSet, sat07) == 1
+    IS07 = reduction_results_07.is_target
+    sol_IS_07 = findbest( IS07, BruteForce() )
+    @test Set( findbest( sat07, BruteForce() ) ) == Set( extract_solution(reduction_results_07, sol_IS_07) )
 end


### PR DESCRIPTION
Achieved:
- Generalize the "3-SAT => Independent Set" to "SAT => Independent Set";
- Generalize to the case when SAT is unsatisfiable (size of the independent size < k (number of clauses) );
- Add more tests;

Questions about the test/rules/rules.jl file:
`extract_solution.(Ref(reduction_result), target_sol)` is not good for the "SAT => Independent Set". Because this is an element-wise operation, the vector of solutions will be broken into individual solutions as input. Sometimes the extracted Independent Set solutions don't cover all the literals. For example, assuming that SAT has three variables (literals) (x, y and z) and the returned solutions only cover x and y. This means that z can take any Bool value (true or false, 0 or 1). This case corresponds to the degenerate solutions.

I suggest that we should modify the test/rules/rules.jl .