### PR TITLE
Fix hard-constraint factoring reductions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ProblemReductions
 
+![Agent maintained](https://img.shields.io/badge/maintenance-agent%20maintained-blue)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://GiggleLiu.github.io/ProblemReductions.jl/dev/)
 [![Build Status](https://github.com/GiggleLiu/ProblemReductions.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/GiggleLiu/ProblemReductions.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/GiggleLiu/ProblemReductions.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/GiggleLiu/ProblemReductions.jl)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,7 +31,7 @@ res = reduceto(paths[1], factoring); # perform the reduction
 problem_size(target_problem(res))
 ```
 The [`Factoring`](@ref) problem is defined with two inputs of bit width 2 and 1, respectively.
-We first query the reduction paths from the [Factoring](@ref) problem to the [SpinGlass](@ref) problem using [`reduction_paths`](@ref), and find multiple paths.
+We first query the reduction paths from the [`Factoring`](@ref) problem to the [`SpinGlass`](@ref) problem using [`reduction_paths`](@ref), and find multiple paths.
 Each path is a [`ReductionPath`](@ref) instance.
 We pick one reduction path and perform the reduction using [`reduceto`](@ref). The result is a [`ConcatenatedReduction`](@ref) instance, which contains not only the target problem, but also the intermediate reductions in the reduction path.
 The target problem is an Ising model with 25 spins, which is exactly solvable using the [`BruteForce`](@ref) method implemented in [`findbest`](@ref):

--- a/src/rules/factoring_sat.jl
+++ b/src/rules/factoring_sat.jl
@@ -17,7 +17,14 @@ end
 
 target_problem(res::ReductionFactoringToSat) = res.circuit
 
-function reduceto(::Type{<:CircuitSAT}, f::Factoring)
+"""
+    reduceto(::Type{<:CircuitSAT}, f::Factoring; use_constraints::Bool=false)
+
+Reduce factoring to a Boolean circuit. Set `use_constraints=true` to enforce the
+circuit equations as hard constraints; the default uses soft objectives, as in
+[`CircuitSAT`](@ref).
+"""
+function reduceto(::Type{<:CircuitSAT}, f::Factoring; use_constraints::Bool=false)
     # construct a circuit that multiplies two numbers
     n1, n2, z = f.m, f.n, f.input
     p = [BooleanExpr(Symbol("p$i")) for i in 1:n1]
@@ -50,7 +57,7 @@ function reduceto(::Type{<:CircuitSAT}, f::Factoring)
     for i in 1:n1+n2
         push!(exprs, Assignment([m[i].var], BooleanExpr(Bool(readbit(z, i)))))
     end
-    sat = CircuitSAT(Circuit(exprs))
+    sat = CircuitSAT(Circuit(exprs); use_constraints)
     findvars(vars) = map(v->findfirst(==(v), sat.symbols), getfield.(vars, :var))
     return ReductionFactoringToSat(sat, findvars(p), findvars(q), findvars(m))
 end

--- a/test/rules/factoring_sat.jl
+++ b/test/rules/factoring_sat.jl
@@ -39,6 +39,26 @@ end
     @test (2* assignment3[:p2]+ assignment3[:p1]) * assignment3[:q1] == 3
 end
 
+@testset "hard constraints" begin
+    for fact in (Factoring(1, 1, 1), Factoring(2, 1, 2), Factoring(2, 1, 3))
+        res = reduceto(CircuitSAT, fact; use_constraints=true)
+        sat = target_problem(res)
+        @test !isempty(ProblemReductions.constraints(sat))
+        @test isempty(ProblemReductions.objectives(sat))
+        solutions = extract_solution.(Ref(res), findbest(sat, BruteForce()))
+        @test Set(solutions) == Set(findbest(fact, BruteForce()))
+    end
+
+    # Two one-bit factors cannot multiply to two. Hard constraints must reject
+    # all assignments, whereas soft objectives still have a best approximation.
+    impossible = Factoring(1, 1, 2)
+    hard = reduceto(CircuitSAT, impossible; use_constraints=true)
+    @test isempty(findbest(target_problem(hard), BruteForce()))
+    soft = reduceto(CircuitSAT, impossible; use_constraints=false)
+    @test isempty(ProblemReductions.constraints(target_problem(soft)))
+    @test !isempty(findbest(target_problem(soft), BruteForce()))
+end
+
 @testset "large circuit" begin
     m = n = 15
     a = 1019


### PR DESCRIPTION
Factoring reductions currently reject `use_constraints=true`, so callers cannot request the hard-constraint CircuitSAT mode. Forward the keyword to CircuitSAT while preserving the existing default.

The regression tests check valid factor extraction and verify that an impossible one-bit factorization has no hard-constraint solutions. The existing large and BigInt circuit tests also pass (1,418 assertions across the factoring reduction test file on Julia 1.12.4). The full package suite also passed on Julia 1.10.12. The two documentation index references were corrected and the GitHub Documentation check passed. Stable and nightly CI are still running; the repository also requires an independent approving review before merge.

Includes the first agent-maintained README badge. Dependency review found JSON 1.8.0 and PrettyTables 3.4.8 need source adaptations; adaptations are in existing PRs #156 and #157. Their combined full suite passed on Julia 1.12.4, with additional compatibility checks covering old/new JSON and PrettyTables combinations and Julia 1.10.12.

Fixes #154.
